### PR TITLE
Fixes #1

### DIFF
--- a/server.js
+++ b/server.js
@@ -13,6 +13,11 @@ app.http().io();
 
 var appDB = {};
 
+function isNormalInteger(str) {
+  var n = ~~Number(str);
+  return String(n) === str && n >= 0;
+}
+
 function fetchBase(url, func) {
   request(url, function(err, res, body) {
     func(err, body);
@@ -46,7 +51,7 @@ function sendTitle(req, title, app) {
 function memberlistUpdate(req, page) {
   // numeric group id? they have different urls
   var name = req.data.name;
-  var url = ('' + parseInt(name, 10)).length == name.length ? ('gid/' + name) : ('groups/' + name);
+  var url = isNormalInteger(name) ? ('gid/' + name) : ('groups/' + name);
   fetchBase('http://steamcommunity.com/' + url + '/memberslistxml/?xml=1&p=' + page, function(err, content) {
     if(err) {
       console.log('Member fetching error for ' + url + '\n' + err);
@@ -80,7 +85,7 @@ function memberlistUpdate(req, page) {
 
 function friendsUpdate(req) {
   var id = req.data.name.substr(8);
-  var url = ('' + parseInt(id, 10)).length == id.length ? ('profiles/' + id) : ('id/' + id);
+  var url = isNormalInteger(id) ? ('profiles/' + id) : ('id/' + id);
   fetchBase('http://steamcommunity.com/' + url + '/friends/?xml=1', function(err, content) {
     if(err) {
       console.log('Friends fetching error for ' + url + '\n' + err);


### PR DESCRIPTION
Of note, one should look for an even better solution as this one will most likely fail when a vanity URL consists of numbers and numbers only (e.g: http://steamcommunity.com/groups/123123154657878, http://steamcommunity.com/id/64564646545678789).
