### PR TITLE
Fix duplicate groups showing but without name

### DIFF
--- a/base.js
+++ b/base.js
@@ -19,14 +19,17 @@ module.exports = {
       } else {
         $ = cheerio.load(content);
 
-        var name = $('h1').text();
-        var groups = [];
+        var name = $('h1').text(),
+            groups = {};
+
         $('a.linkTitle').each(function(i, elem) {
-          var obj = $(this);
-          var link = obj.attr('href');
+          var obj = $(this),
+              link = obj.attr('href');
+
           link = link.substr(link.lastIndexOf('/') + 1);
-          groups[groups.length] = {url: link, name: obj.text()};
+          groups[link] = {url: link, name: obj.text()};
         });
+
         func(null, name, groups);
       }
     });


### PR DESCRIPTION
The official groups seem to show up twice, with and without the name being shown.

http://puu.sh/442CZ.png
